### PR TITLE
AD-006 formatter

### DIFF
--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -4,7 +4,6 @@ on: [ push, pull_request ]
 
 
 jobs:
-  name: "Check Kotlin formatting"
   kotlin_format_check:
     name: "Run Spotless Kotlin Format Check"
     runs-on: ubuntu-latest

--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -1,6 +1,6 @@
 name: Format Kotlin with Spotless Ktfmt (All Files)
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   spotless:
@@ -15,4 +15,6 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - run: mvn spotless:check
+      - run: |
+          cd rest
+          mvn spotless:check

--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -1,9 +1,12 @@
-name: Format Kotlin with Spotless Ktfmt (All Files)
+name: Check Kotlin formatting (spotless, ktfmt)
 
 on: [ push, pull_request ]
 
+
 jobs:
-  spotless:
+  name: "Check Kotlin formatting"
+  kotlin_format_check:
+    name: "Run Spotless Kotlin Format Check"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -1,0 +1,18 @@
+name: Format Kotlin with Spotless Ktfmt (All Files)
+
+on: [push, pull_request]
+
+jobs:
+  spotless:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - run: mvn spotless:check

--- a/.github/workflows/kotlin-format-check.yaml
+++ b/.github/workflows/kotlin-format-check.yaml
@@ -1,6 +1,12 @@
 name: Kotlin format check (spotless, ktfmt)
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   kotlin_format_check:

--- a/.github/workflows/kotlin-format-check.yaml
+++ b/.github/workflows/kotlin-format-check.yaml
@@ -1,11 +1,10 @@
-name: Check Kotlin formatting (spotless, ktfmt)
+name: Kotlin format check (spotless, ktfmt)
 
 on: [ push, pull_request ]
 
-
 jobs:
   kotlin_format_check:
-    name: "Run Spotless Kotlin Format Check"
+    name: "Kotlin Format Check"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 This project uses **Ktfmt (kotlinlang style)** for code formatting. 
 
-Run `mvn spotless:check` to verify formatting or `mvn spotless:apply` to apply formatting, both limited to files changed since the origin/master branch.
+Go into `/rest` directory and run  `mvn spotless:check` to verify formatting or `mvn spotless:apply` to apply formatting, both limited to files changed since the origin/master branch. 
 
 IntelliJ users can also install the ktfmt plugin to simplify code formatting within the IDE. 
 Make sure to set the style to kotlinlang in the plugin settings.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
   POSTGRES_PASSWORD=your_postgres_password_here
   ```
 
+## Code formatting
+
+### Ktfmt
+
+This project uses **Ktfmt (kotlinlang style)** for code formatting. 
+
+Run `mvn spotless:check` to verify formatting or `mvn spotless:apply` to apply formatting, both limited to files changed since the origin/master branch.
+
+IntelliJ users can also install the ktfmt plugin to simplify code formatting within the IDE. 
+Make sure to set the style to kotlinlang in the plugin settings.
+
 ## Commit and Branch Naming Conventions
 
 ### Commit Messages

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -83,8 +83,6 @@
                         <ktfmt>
                             <version>${ktfmt.version}</version>
                             <style>KOTLINLANG</style>
-                            <removeUnusedImports>true</removeUnusedImports>
-                            <manageTrailingCommas>true</manageTrailingCommas>
                         </ktfmt>
                     </kotlin>
                 </configuration>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.tomtom.anomaly-detector</groupId>
@@ -21,13 +21,15 @@
         <org.springdoc>2.8.9</org.springdoc>
         <nida.version>2.19.0</nida.version>
         <jackson.module.kotlin.version>2.19.1</jackson.module.kotlin.version>
+        <spotless.version>2.46.1</spotless.version>
+        <ktfmt.version>0.56</ktfmt.version>
     </properties>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.0.6</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
 
@@ -62,6 +64,30 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>apply</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <ratchetFrom>origin/master</ratchetFrom>
+                    <kotlin>
+                        <ktfmt>
+                            <version>${ktfmt.version}</version>
+                            <style>KOTLINLANG</style>
+                            <removeUnusedImports>true</removeUnusedImports>
+                            <manageTrailingCommas>true</manageTrailingCommas>
+                        </ktfmt>
+                    </kotlin>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -143,5 +169,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>


### PR DESCRIPTION
### Added ktfmt formatter with spotless in the rest folder.
Run these commands inside the `rest` folder:
`mvn spotless:check` to check formatting
`mvn spotless:apply` to fix formatting
GitHub Actions will check formatting on changed files.
Note: Formatting all `.kt` files will be done in another PR.

